### PR TITLE
Cleanup code styles

### DIFF
--- a/src/main/java/org/embulk/util/dynamic/AbstractDynamicColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/AbstractDynamicColumnSetter.java
@@ -22,36 +22,45 @@ import org.embulk.spi.PageBuilder;
 import org.msgpack.value.Value;
 
 public abstract class AbstractDynamicColumnSetter implements DynamicColumnSetter {
-    protected AbstractDynamicColumnSetter(PageBuilder pageBuilder, Column column,
-            DefaultValueSetter defaultValue) {
+    protected AbstractDynamicColumnSetter(
+            final PageBuilder pageBuilder,
+            final Column column,
+            final DefaultValueSetter defaultValueSetter) {
         this.pageBuilder = pageBuilder;
         this.column = column;
-        this.defaultValue = defaultValue;
+        this.defaultValueSetter = defaultValueSetter;
     }
 
+    @Override
     public abstract void setNull();
 
+    @Override
     public abstract void set(boolean value);
 
+    @Override
     public abstract void set(long value);
 
+    @Override
     public abstract void set(double value);
 
+    @Override
     public abstract void set(String value);
 
     @Deprecated
+    @Override
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
     public abstract void set(org.embulk.spi.time.Timestamp value);
 
     @Override
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
-    public void set(Instant value) {
+    public void set(final Instant value) {
         this.set(org.embulk.spi.time.Timestamp.ofInstant(value));
     }
 
+    @Override
     public abstract void set(Value value);
 
     protected final PageBuilder pageBuilder;
     protected final Column column;
-    protected final DefaultValueSetter defaultValue;
+    protected final DefaultValueSetter defaultValueSetter;
 }

--- a/src/main/java/org/embulk/util/dynamic/AbstractDynamicColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/AbstractDynamicColumnSetter.java
@@ -22,10 +22,6 @@ import org.embulk.spi.PageBuilder;
 import org.msgpack.value.Value;
 
 public abstract class AbstractDynamicColumnSetter implements DynamicColumnSetter {
-    protected final PageBuilder pageBuilder;
-    protected final Column column;
-    protected final DefaultValueSetter defaultValue;
-
     protected AbstractDynamicColumnSetter(PageBuilder pageBuilder, Column column,
             DefaultValueSetter defaultValue) {
         this.pageBuilder = pageBuilder;
@@ -54,4 +50,8 @@ public abstract class AbstractDynamicColumnSetter implements DynamicColumnSetter
     }
 
     public abstract void set(Value value);
+
+    protected final PageBuilder pageBuilder;
+    protected final Column column;
+    protected final DefaultValueSetter defaultValue;
 }

--- a/src/main/java/org/embulk/util/dynamic/BooleanColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/BooleanColumnSetter.java
@@ -23,14 +23,6 @@ import org.embulk.spi.PageBuilder;
 import org.msgpack.value.Value;
 
 public class BooleanColumnSetter extends AbstractDynamicColumnSetter {
-    private static final ImmutableSet<String> TRUE_STRINGS =
-            ImmutableSet.of(
-                    "true", "True", "TRUE",
-                    "yes", "Yes", "YES",
-                    "t", "T", "y", "Y",
-                    "on", "On",
-                    "ON", "1");
-
     public BooleanColumnSetter(PageBuilder pageBuilder, Column column,
             DefaultValueSetter defaultValue) {
         super(pageBuilder, column, defaultValue);
@@ -80,4 +72,12 @@ public class BooleanColumnSetter extends AbstractDynamicColumnSetter {
     public void set(Value v) {
         defaultValue.setBoolean(pageBuilder, column);
     }
+
+    private static final ImmutableSet<String> TRUE_STRINGS =
+            ImmutableSet.of(
+                    "true", "True", "TRUE",
+                    "yes", "Yes", "YES",
+                    "t", "T", "y", "Y",
+                    "on", "On",
+                    "ON", "1");
 }

--- a/src/main/java/org/embulk/util/dynamic/BooleanColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/BooleanColumnSetter.java
@@ -23,61 +23,62 @@ import org.embulk.spi.PageBuilder;
 import org.msgpack.value.Value;
 
 public class BooleanColumnSetter extends AbstractDynamicColumnSetter {
-    public BooleanColumnSetter(PageBuilder pageBuilder, Column column,
-            DefaultValueSetter defaultValue) {
-        super(pageBuilder, column, defaultValue);
+    public BooleanColumnSetter(
+            final PageBuilder pageBuilder,
+            final Column column,
+            final DefaultValueSetter defaultValueSetter) {
+        super(pageBuilder, column, defaultValueSetter);
     }
 
     @Override
     public void setNull() {
-        pageBuilder.setNull(column);
+        this.pageBuilder.setNull(this.column);
     }
 
     @Override
-    public void set(boolean v) {
-        pageBuilder.setBoolean(column, v);
+    public void set(final boolean v) {
+        this.pageBuilder.setBoolean(this.column, v);
     }
 
     @Override
-    public void set(long v) {
-        pageBuilder.setBoolean(column, v > 0);
+    public void set(final long v) {
+        this.pageBuilder.setBoolean(this.column, v > 0);
     }
 
     @Override
-    public void set(double v) {
-        pageBuilder.setBoolean(column, v > 0.0);
+    public void set(final double v) {
+        this.pageBuilder.setBoolean(this.column, v > 0.0);
     }
 
     @Override
-    public void set(String v) {
+    public void set(final String v) {
         if (TRUE_STRINGS.contains(v)) {
-            pageBuilder.setBoolean(column, true);
+            this.pageBuilder.setBoolean(this.column, true);
         } else {
-            defaultValue.setBoolean(pageBuilder, column);
+            this.defaultValueSetter.setBoolean(this.pageBuilder, column);
         }
     }
 
     @Override
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
-    public void set(org.embulk.spi.time.Timestamp v) {
-        defaultValue.setBoolean(pageBuilder, column);
+    public void set(final org.embulk.spi.time.Timestamp v) {
+        this.defaultValueSetter.setBoolean(this.pageBuilder, this.column);
     }
 
     @Override
-    public void set(Instant v) {
-        defaultValue.setBoolean(pageBuilder, column);
+    public void set(final Instant v) {
+        this.defaultValueSetter.setBoolean(this.pageBuilder, this.column);
     }
 
     @Override
-    public void set(Value v) {
-        defaultValue.setBoolean(pageBuilder, column);
+    public void set(final Value v) {
+        this.defaultValueSetter.setBoolean(this.pageBuilder, this.column);
     }
 
-    private static final ImmutableSet<String> TRUE_STRINGS =
-            ImmutableSet.of(
-                    "true", "True", "TRUE",
-                    "yes", "Yes", "YES",
-                    "t", "T", "y", "Y",
-                    "on", "On",
-                    "ON", "1");
+    private static final ImmutableSet<String> TRUE_STRINGS = ImmutableSet.of(
+            "true", "True", "TRUE",
+            "yes", "Yes", "YES",
+            "t", "T", "y", "Y",
+            "on", "On",
+            "ON", "1");
 }

--- a/src/main/java/org/embulk/util/dynamic/DoubleColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/DoubleColumnSetter.java
@@ -22,60 +22,62 @@ import org.embulk.spi.PageBuilder;
 import org.msgpack.value.Value;
 
 public class DoubleColumnSetter extends AbstractDynamicColumnSetter {
-    public DoubleColumnSetter(PageBuilder pageBuilder, Column column,
-            DefaultValueSetter defaultValue) {
-        super(pageBuilder, column, defaultValue);
+    public DoubleColumnSetter(
+            final PageBuilder pageBuilder,
+            final Column column,
+            final DefaultValueSetter defaultValueSetter) {
+        super(pageBuilder, column, defaultValueSetter);
     }
 
     @Override
     public void setNull() {
-        pageBuilder.setNull(column);
+        this.pageBuilder.setNull(this.column);
     }
 
     @Override
-    public void set(boolean v) {
-        pageBuilder.setDouble(column, v ? 1.0 : 0.0);
+    public void set(final boolean v) {
+        this.pageBuilder.setDouble(this.column, v ? 1.0 : 0.0);
     }
 
     @Override
-    public void set(long v) {
-        pageBuilder.setDouble(column, (double) v);
+    public void set(final long v) {
+        this.pageBuilder.setDouble(this.column, (double) v);
     }
 
     @Override
-    public void set(double v) {
-        pageBuilder.setDouble(column, v);
+    public void set(final double v) {
+        this.pageBuilder.setDouble(this.column, v);
     }
 
     @Override
-    public void set(String v) {
-        double dv;
+    public void set(final String v) {
+        final double dv;
         try {
             dv = Double.parseDouble(v);
-        } catch (NumberFormatException e) {
-            defaultValue.setDouble(pageBuilder, column);
+        } catch (final NumberFormatException ex) {
+            this.defaultValueSetter.setDouble(this.pageBuilder, this.column);
             return;
         }
-        pageBuilder.setDouble(column, dv);
+        this.pageBuilder.setDouble(this.column, dv);
     }
 
     @Override
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
     public void set(final org.embulk.spi.time.Timestamp v) {
-        double sec = (double) v.getEpochSecond();
-        double frac = v.getNano() / 1000000000.0;
-        pageBuilder.setDouble(column, sec + frac);
+        final double sec = (double) v.getEpochSecond();
+        final double frac = v.getNano() / 1000000000.0;
+        this.pageBuilder.setDouble(this.column, sec + frac);
     }
 
     @Override
-    public void set(Instant v) {
-        double sec = (double) v.getEpochSecond();
-        double frac = v.getNano() / 1000000000.0;
-        pageBuilder.setDouble(column, sec + frac);
+    public void set(final Instant v) {
+        final double sec = (double) v.getEpochSecond();
+        final double frac = v.getNano() / 1000000000.0;
+        this.pageBuilder.setDouble(this.column, sec + frac);
     }
 
     @Override
-    public void set(Value v) {
-        defaultValue.setDouble(pageBuilder, column);
+    public void set(final Value v) {
+        this.defaultValueSetter.setDouble(this.pageBuilder, this.column);
     }
 }

--- a/src/main/java/org/embulk/util/dynamic/DynamicColumnNotFoundException.java
+++ b/src/main/java/org/embulk/util/dynamic/DynamicColumnNotFoundException.java
@@ -17,7 +17,7 @@
 package org.embulk.util.dynamic;
 
 public class DynamicColumnNotFoundException extends RuntimeException {
-    public DynamicColumnNotFoundException(String message) {
+    public DynamicColumnNotFoundException(final String message) {
         super(message);
     }
 }

--- a/src/main/java/org/embulk/util/dynamic/DynamicColumnSetterFactory.java
+++ b/src/main/java/org/embulk/util/dynamic/DynamicColumnSetterFactory.java
@@ -29,10 +29,6 @@ import org.embulk.spi.type.TimestampType;
 import org.embulk.spi.type.Type;
 
 class DynamicColumnSetterFactory {
-    private final DefaultValueSetter defaultValue;
-    private final DynamicPageBuilder.BuilderTask task;
-    private final boolean useColumnForTimestampMetadata;
-
     private DynamicColumnSetterFactory(
             final DynamicPageBuilder.BuilderTask task,
             final DefaultValueSetter defaultValue,
@@ -133,4 +129,8 @@ class DynamicColumnSetterFactory {
     private String getFormatFromTimestampTypeWithDepracationSuppressed(final TimestampType timestampType) {
         return timestampType.getFormat();
     }
+
+    private final DefaultValueSetter defaultValue;
+    private final DynamicPageBuilder.BuilderTask task;
+    private final boolean useColumnForTimestampMetadata;
 }

--- a/src/main/java/org/embulk/util/dynamic/DynamicColumnSetterFactory.java
+++ b/src/main/java/org/embulk/util/dynamic/DynamicColumnSetterFactory.java
@@ -31,42 +31,42 @@ import org.embulk.spi.type.Type;
 class DynamicColumnSetterFactory {
     private DynamicColumnSetterFactory(
             final DynamicPageBuilder.BuilderTask task,
-            final DefaultValueSetter defaultValue,
+            final DefaultValueSetter defaultValueSetter,
             final boolean useColumnForTimestampMetadata) {
-        this.defaultValue = defaultValue;
+        this.defaultValueSetter = defaultValueSetter;
         this.task = task;
         this.useColumnForTimestampMetadata = useColumnForTimestampMetadata;
     }
 
     static DynamicColumnSetterFactory createWithTimestampMetadataFromBuilderTask(
             final DynamicPageBuilder.BuilderTask task,
-            final DefaultValueSetter defaultValue) {
-        return new DynamicColumnSetterFactory(task, defaultValue, false);
+            final DefaultValueSetter defaultValueSetter) {
+        return new DynamicColumnSetterFactory(task, defaultValueSetter, false);
     }
 
     static DynamicColumnSetterFactory createWithTimestampMetadataFromColumn(
             final DynamicPageBuilder.BuilderTask task,
-            final DefaultValueSetter defaultValue) {
-        return new DynamicColumnSetterFactory(task, defaultValue, true);
+            final DefaultValueSetter defaultValueSetter) {
+        return new DynamicColumnSetterFactory(task, defaultValueSetter, true);
     }
 
-    public static DefaultValueSetter nullDefaultValue() {
+    public static DefaultValueSetter nullDefaultValueSetter() {
         return new NullDefaultValueSetter();
     }
 
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
-    public DynamicColumnSetter newColumnSetter(PageBuilder pageBuilder, Column column) {
-        Type type = column.getType();
+    public DynamicColumnSetter newColumnSetter(final PageBuilder pageBuilder, final Column column) {
+        final Type type = column.getType();
         if (type instanceof BooleanType) {
-            return new BooleanColumnSetter(pageBuilder, column, defaultValue);
+            return new BooleanColumnSetter(pageBuilder, column, this.defaultValueSetter);
         } else if (type instanceof LongType) {
-            return new LongColumnSetter(pageBuilder, column, defaultValue);
+            return new LongColumnSetter(pageBuilder, column, this.defaultValueSetter);
         } else if (type instanceof DoubleType) {
-            return new DoubleColumnSetter(pageBuilder, column, defaultValue);
+            return new DoubleColumnSetter(pageBuilder, column, this.defaultValueSetter);
         } else if (type instanceof StringType) {
             final org.embulk.spi.time.TimestampFormatter formatter = org.embulk.spi.time.TimestampFormatter.of(
                     getTimestampFormatForFormatter(column), getTimeZoneId(column));
-            return new StringColumnSetter(pageBuilder, column, defaultValue, formatter);
+            return new StringColumnSetter(pageBuilder, column, this.defaultValueSetter, formatter);
         } else if (type instanceof TimestampType) {
             // TODO use flexible time format like Ruby's Time.parse
             final org.embulk.spi.time.TimestampParser parser;
@@ -78,17 +78,17 @@ class DynamicColumnSetterFactory {
             } else {
                 parser = org.embulk.spi.time.TimestampParser.of(getTimestampFormatForParser(column), getTimeZoneId(column));
             }
-            return new TimestampColumnSetter(pageBuilder, column, defaultValue, parser);
+            return new TimestampColumnSetter(pageBuilder, column, this.defaultValueSetter, parser);
         } else if (type instanceof JsonType) {
             final org.embulk.spi.time.TimestampFormatter formatter = org.embulk.spi.time.TimestampFormatter.of(
                     getTimestampFormatForFormatter(column), getTimeZoneId(column));
-            return new JsonColumnSetter(pageBuilder, column, defaultValue, formatter);
+            return new JsonColumnSetter(pageBuilder, column, this.defaultValueSetter, formatter);
         }
         throw new ConfigException("Unknown column type: " + type);
     }
 
-    private String getTimestampFormatForFormatter(Column column) {
-        DynamicPageBuilder.ColumnOption option = getColumnOption(column);
+    private String getTimestampFormatForFormatter(final Column column) {
+        final DynamicPageBuilder.ColumnOption option = getColumnOption(column);
         if (option != null) {
             return option.getTimestampFormatString();
         } else {
@@ -96,8 +96,8 @@ class DynamicColumnSetterFactory {
         }
     }
 
-    private String getTimestampFormatForParser(Column column) {
-        DynamicPageBuilder.ColumnOption option = getColumnOption(column);
+    private String getTimestampFormatForParser(final Column column) {
+        final DynamicPageBuilder.ColumnOption option = getColumnOption(column);
         if (option != null) {
             return option.getTimestampFormatString();
         } else {
@@ -105,18 +105,18 @@ class DynamicColumnSetterFactory {
         }
     }
 
-    private String getTimeZoneId(Column column) {
-        DynamicPageBuilder.ColumnOption option = getColumnOption(column);
+    private String getTimeZoneId(final Column column) {
+        final DynamicPageBuilder.ColumnOption option = getColumnOption(column);
         if (option != null) {
-            return option.getTimeZoneId().or(task.getDefaultTimeZoneId());
+            return option.getTimeZoneId().or(this.task.getDefaultTimeZoneId());
         } else {
-            return task.getDefaultTimeZoneId();
+            return this.task.getDefaultTimeZoneId();
         }
     }
 
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1301
-    private DynamicPageBuilder.ColumnOption getColumnOption(Column column) {
-        ConfigSource option = task.getColumnOptions().get(column.getName());
+    private DynamicPageBuilder.ColumnOption getColumnOption(final Column column) {
+        final ConfigSource option = this.task.getColumnOptions().get(column.getName());
         if (option != null) {
             return option.loadConfig(DynamicPageBuilder.ColumnOption.class);
         } else {
@@ -130,7 +130,7 @@ class DynamicColumnSetterFactory {
         return timestampType.getFormat();
     }
 
-    private final DefaultValueSetter defaultValue;
+    private final DefaultValueSetter defaultValueSetter;
     private final DynamicPageBuilder.BuilderTask task;
     private final boolean useColumnForTimestampMetadata;
 }

--- a/src/main/java/org/embulk/util/dynamic/DynamicPageBuilder.java
+++ b/src/main/java/org/embulk/util/dynamic/DynamicPageBuilder.java
@@ -40,10 +40,10 @@ public class DynamicPageBuilder implements AutoCloseable {
             final PageOutput output) {
         this.pageBuilder = new PageBuilder(allocator, schema, output);
         this.schema = schema;
-        ImmutableList.Builder<DynamicColumnSetter> setters = ImmutableList.builder();
-        ImmutableMap.Builder<String, DynamicColumnSetter> lookup = ImmutableMap.builder();
-        for (Column c : schema.getColumns()) {
-            DynamicColumnSetter setter = factory.newColumnSetter(pageBuilder, c);
+        final ImmutableList.Builder<DynamicColumnSetter> setters = ImmutableList.builder();
+        final ImmutableMap.Builder<String, DynamicColumnSetter> lookup = ImmutableMap.builder();
+        for (final Column c : schema.getColumns()) {
+            final DynamicColumnSetter setter = factory.newColumnSetter(this.pageBuilder, c);
             setters.add(setter);
             lookup.put(c.getName(), setter);
         }
@@ -52,24 +52,24 @@ public class DynamicPageBuilder implements AutoCloseable {
     }
 
     public static DynamicPageBuilder createWithTimestampMetadataFromBuilderTask(
-            BuilderTask task,
-            BufferAllocator allocator,
-            Schema schema,
-            PageOutput output) {
+            final BuilderTask task,
+            final BufferAllocator allocator,
+            final Schema schema,
+            final PageOutput output) {
         // TODO configurable default value
-        DynamicColumnSetterFactory factory = DynamicColumnSetterFactory.createWithTimestampMetadataFromBuilderTask(
-                task, DynamicColumnSetterFactory.nullDefaultValue());
+        final DynamicColumnSetterFactory factory = DynamicColumnSetterFactory.createWithTimestampMetadataFromBuilderTask(
+                task, DynamicColumnSetterFactory.nullDefaultValueSetter());
         return new DynamicPageBuilder(factory, allocator, schema, output);
     }
 
     public static DynamicPageBuilder createWithTimestampMetadataFromColumn(
-            BuilderTask task,
-            BufferAllocator allocator,
-            Schema schema,
-            PageOutput output) {
+            final BuilderTask task,
+            final BufferAllocator allocator,
+            final Schema schema,
+            final PageOutput output) {
         // TODO configurable default value
-        DynamicColumnSetterFactory factory = DynamicColumnSetterFactory.createWithTimestampMetadataFromColumn(
-                task, DynamicColumnSetterFactory.nullDefaultValue());
+        final DynamicColumnSetterFactory factory = DynamicColumnSetterFactory.createWithTimestampMetadataFromColumn(
+                task, DynamicColumnSetterFactory.nullDefaultValueSetter());
         return new DynamicPageBuilder(factory, allocator, schema, output);
     }
 
@@ -125,37 +125,37 @@ public class DynamicPageBuilder implements AutoCloseable {
     }
 
     public List<Column> getColumns() {
-        return schema.getColumns();
+        return this.schema.getColumns();
     }
 
-    public DynamicColumnSetter column(Column c) {
-        return setters[c.getIndex()];
+    public DynamicColumnSetter column(final Column c) {
+        return this.setters[c.getIndex()];
     }
 
-    public DynamicColumnSetter column(int index) {
-        if (index < 0 || setters.length <= index) {
+    public DynamicColumnSetter column(final int index) {
+        if (index < 0 || this.setters.length <= index) {
             throw new DynamicColumnNotFoundException("Column index '" + index + "' is not exist");
         }
-        return setters[index];
+        return this.setters[index];
     }
 
-    public DynamicColumnSetter lookupColumn(String columnName) {
-        DynamicColumnSetter setter = columnLookup.get(columnName);
+    public DynamicColumnSetter lookupColumn(final String columnName) {
+        final DynamicColumnSetter setter = this.columnLookup.get(columnName);
         if (setter == null) {
             throw new DynamicColumnNotFoundException("Column '" + columnName + "' is not exist");
         }
         return setter;
     }
 
-    public DynamicColumnSetter columnOrSkip(int index) {
-        if (index < 0 || setters.length <= index) {
+    public DynamicColumnSetter columnOrSkip(final int index) {
+        if (index < 0 || this.setters.length <= index) {
             return SkipColumnSetter.get();
         }
-        return setters[index];
+        return this.setters[index];
     }
 
-    public DynamicColumnSetter columnOrSkip(String columnName) {
-        DynamicColumnSetter setter = columnLookup.get(columnName);
+    public DynamicColumnSetter columnOrSkip(final String columnName) {
+        final DynamicColumnSetter setter = this.columnLookup.get(columnName);
         if (setter == null) {
             return SkipColumnSetter.get();
         }
@@ -163,33 +163,33 @@ public class DynamicPageBuilder implements AutoCloseable {
     }
 
     // for jruby
-    protected DynamicColumnSetter columnOrNull(int index) {
-        if (index < 0 || setters.length <= index) {
+    protected DynamicColumnSetter columnOrNull(final int index) {
+        if (index < 0 || this.setters.length <= index) {
             return null;
         }
-        return setters[index];
+        return this.setters[index];
     }
 
     // for jruby
-    protected DynamicColumnSetter columnOrNull(String columnName) {
-        return columnLookup.get(columnName);
+    protected DynamicColumnSetter columnOrNull(final String columnName) {
+        return this.columnLookup.get(columnName);
     }
 
     public void addRecord() {
-        pageBuilder.addRecord();
+        this.pageBuilder.addRecord();
     }
 
     public void flush() {
-        pageBuilder.flush();
+        this.pageBuilder.flush();
     }
 
     public void finish() {
-        pageBuilder.finish();
+        this.pageBuilder.finish();
     }
 
     @Override
     public void close() {
-        pageBuilder.close();
+        this.pageBuilder.close();
     }
 
     private final PageBuilder pageBuilder;

--- a/src/main/java/org/embulk/util/dynamic/JsonColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/JsonColumnSetter.java
@@ -24,9 +24,6 @@ import org.msgpack.value.ValueFactory;
 
 public class JsonColumnSetter extends AbstractDynamicColumnSetter {
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
-    private final org.embulk.spi.time.TimestampFormatter timestampFormatter;
-
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
     public JsonColumnSetter(PageBuilder pageBuilder, Column column,
                             DefaultValueSetter defaultValue,
                             org.embulk.spi.time.TimestampFormatter timestampFormatter) {
@@ -75,4 +72,7 @@ public class JsonColumnSetter extends AbstractDynamicColumnSetter {
     public void set(Value v) {
         pageBuilder.setJson(column, v);
     }
+
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
+    private final org.embulk.spi.time.TimestampFormatter timestampFormatter;
 }

--- a/src/main/java/org/embulk/util/dynamic/JsonColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/JsonColumnSetter.java
@@ -24,53 +24,55 @@ import org.msgpack.value.ValueFactory;
 
 public class JsonColumnSetter extends AbstractDynamicColumnSetter {
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
-    public JsonColumnSetter(PageBuilder pageBuilder, Column column,
-                            DefaultValueSetter defaultValue,
-                            org.embulk.spi.time.TimestampFormatter timestampFormatter) {
-        super(pageBuilder, column, defaultValue);
+    public JsonColumnSetter(
+            final PageBuilder pageBuilder,
+            final Column column,
+            final DefaultValueSetter defaultValueSetter,
+            final org.embulk.spi.time.TimestampFormatter timestampFormatter) {
+        super(pageBuilder, column, defaultValueSetter);
         this.timestampFormatter = timestampFormatter;
     }
 
     @Override
     public void setNull() {
-        pageBuilder.setNull(column);
+        this.pageBuilder.setNull(this.column);
     }
 
     @Override
-    public void set(boolean v) {
-        pageBuilder.setJson(column, ValueFactory.newBoolean(v));
+    public void set(final boolean v) {
+        this.pageBuilder.setJson(this.column, ValueFactory.newBoolean(v));
     }
 
     @Override
-    public void set(long v) {
-        pageBuilder.setJson(column, ValueFactory.newInteger(v));
+    public void set(final long v) {
+        this.pageBuilder.setJson(this.column, ValueFactory.newInteger(v));
     }
 
     @Override
-    public void set(double v) {
-        pageBuilder.setJson(column, ValueFactory.newFloat(v));
+    public void set(final double v) {
+        this.pageBuilder.setJson(this.column, ValueFactory.newFloat(v));
     }
 
     @Override
-    public void set(String v) {
-        pageBuilder.setJson(column, ValueFactory.newString(v));
+    public void set(final String v) {
+        this.pageBuilder.setJson(this.column, ValueFactory.newString(v));
     }
 
     @Override
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
     public void set(final org.embulk.spi.time.Timestamp v) {
-        pageBuilder.setJson(column, ValueFactory.newString(timestampFormatter.format(v)));
+        this.pageBuilder.setJson(this.column, ValueFactory.newString(timestampFormatter.format(v)));
     }
 
     @Override
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
-    public void set(Instant v) {
-        pageBuilder.setJson(column, ValueFactory.newString(timestampFormatter.format(org.embulk.spi.time.Timestamp.ofInstant(v))));
+    public void set(final Instant v) {
+        this.pageBuilder.setJson(this.column, ValueFactory.newString(timestampFormatter.format(org.embulk.spi.time.Timestamp.ofInstant(v))));
     }
 
     @Override
-    public void set(Value v) {
-        pageBuilder.setJson(column, v);
+    public void set(final Value v) {
+        this.pageBuilder.setJson(this.column, v);
     }
 
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298

--- a/src/main/java/org/embulk/util/dynamic/LongColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/LongColumnSetter.java
@@ -24,65 +24,67 @@ import org.embulk.spi.PageBuilder;
 import org.msgpack.value.Value;
 
 public class LongColumnSetter extends AbstractDynamicColumnSetter {
-    public LongColumnSetter(PageBuilder pageBuilder, Column column,
-            DefaultValueSetter defaultValue) {
-        super(pageBuilder, column, defaultValue);
+    public LongColumnSetter(
+            final PageBuilder pageBuilder,
+            final Column column,
+            final DefaultValueSetter defaultValueSetter) {
+        super(pageBuilder, column, defaultValueSetter);
     }
 
     @Override
     public void setNull() {
-        pageBuilder.setNull(column);
+        this.pageBuilder.setNull(this.column);
     }
 
     @Override
-    public void set(boolean v) {
-        pageBuilder.setLong(column, v ? 1L : 0L);
+    public void set(final boolean v) {
+        this.pageBuilder.setLong(this.column, v ? 1L : 0L);
     }
 
     @Override
-    public void set(long v) {
-        pageBuilder.setLong(column, v);
+    public void set(final long v) {
+        this.pageBuilder.setLong(this.column, v);
     }
 
     @Override
-    public void set(double v) {
-        long lv;
+    public void set(final double v) {
+        final long lv;
         try {
             // TODO configurable rounding mode
             lv = DoubleMath.roundToLong(v, RoundingMode.HALF_UP);
-        } catch (ArithmeticException ex) {
+        } catch (final ArithmeticException ex) {
             // NaN / Infinite / -Infinite
-            defaultValue.setLong(pageBuilder, column);
+            this.defaultValueSetter.setLong(this.pageBuilder, this.column);
             return;
         }
-        pageBuilder.setLong(column, lv);
+        this.pageBuilder.setLong(this.column, lv);
     }
 
     @Override
-    public void set(String v) {
-        long lv;
+    public void set(final String v) {
+        final long lv;
         try {
             lv = Long.parseLong(v);
-        } catch (NumberFormatException e) {
-            defaultValue.setLong(pageBuilder, column);
+        } catch (final NumberFormatException ex) {
+            this.defaultValueSetter.setLong(this.pageBuilder, this.column);
             return;
         }
-        pageBuilder.setLong(column, lv);
+        this.pageBuilder.setLong(this.column, lv);
     }
 
     @Override
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
     public void set(final org.embulk.spi.time.Timestamp v) {
-        pageBuilder.setLong(column, v.getEpochSecond());
+        this.pageBuilder.setLong(this.column, v.getEpochSecond());
     }
 
     @Override
-    public void set(Instant v) {
-        pageBuilder.setLong(column, v.getEpochSecond());
+    public void set(final Instant v) {
+        this.pageBuilder.setLong(this.column, v.getEpochSecond());
     }
 
     @Override
-    public void set(Value v) {
-        defaultValue.setLong(pageBuilder, column);
+    public void set(final Value v) {
+        this.defaultValueSetter.setLong(this.pageBuilder, this.column);
     }
 }

--- a/src/main/java/org/embulk/util/dynamic/NullDefaultValueSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/NullDefaultValueSetter.java
@@ -20,27 +20,33 @@ import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
 
 public class NullDefaultValueSetter implements DefaultValueSetter {
-    public void setBoolean(PageBuilder pageBuilder, Column c) {
+    @Override
+    public void setBoolean(final PageBuilder pageBuilder, final Column c) {
         pageBuilder.setNull(c);
     }
 
-    public void setLong(PageBuilder pageBuilder, Column c) {
+    @Override
+    public void setLong(final PageBuilder pageBuilder, final Column c) {
         pageBuilder.setNull(c);
     }
 
-    public void setDouble(PageBuilder pageBuilder, Column c) {
+    @Override
+    public void setDouble(final PageBuilder pageBuilder, final Column c) {
         pageBuilder.setNull(c);
     }
 
-    public void setString(PageBuilder pageBuilder, Column c) {
+    @Override
+    public void setString(final PageBuilder pageBuilder, final Column c) {
         pageBuilder.setNull(c);
     }
 
-    public void setTimestamp(PageBuilder pageBuilder, Column c) {
+    @Override
+    public void setTimestamp(final PageBuilder pageBuilder, final Column c) {
         pageBuilder.setNull(c);
     }
 
-    public void setJson(PageBuilder pageBuilder, Column c) {
+    @Override
+    public void setJson(final PageBuilder pageBuilder, final Column c) {
         pageBuilder.setNull(c);
     }
 }

--- a/src/main/java/org/embulk/util/dynamic/SkipColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/SkipColumnSetter.java
@@ -20,14 +20,12 @@ import java.time.Instant;
 import org.msgpack.value.Value;
 
 public class SkipColumnSetter extends AbstractDynamicColumnSetter {
-    private static final SkipColumnSetter instance = new SkipColumnSetter();
+    private SkipColumnSetter() {
+        super(null, null, null);
+    }
 
     public static SkipColumnSetter get() {
         return instance;
-    }
-
-    private SkipColumnSetter() {
-        super(null, null, null);
     }
 
     @Override
@@ -54,4 +52,6 @@ public class SkipColumnSetter extends AbstractDynamicColumnSetter {
 
     @Override
     public void set(Value v) {}
+
+    private static final SkipColumnSetter instance = new SkipColumnSetter();
 }

--- a/src/main/java/org/embulk/util/dynamic/SkipColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/SkipColumnSetter.java
@@ -32,26 +32,26 @@ public class SkipColumnSetter extends AbstractDynamicColumnSetter {
     public void setNull() {}
 
     @Override
-    public void set(boolean v) {}
+    public void set(final boolean v) {}
 
     @Override
-    public void set(long v) {}
+    public void set(final long v) {}
 
     @Override
-    public void set(double v) {}
+    public void set(final double v) {}
 
     @Override
-    public void set(String v) {}
+    public void set(final String v) {}
 
     @Override
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
     public void set(final org.embulk.spi.time.Timestamp v) {}
 
     @Override
-    public void set(Instant v) {}
+    public void set(final Instant v) {}
 
     @Override
-    public void set(Value v) {}
+    public void set(final Value v) {}
 
     private static final SkipColumnSetter instance = new SkipColumnSetter();
 }

--- a/src/main/java/org/embulk/util/dynamic/StringColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/StringColumnSetter.java
@@ -23,9 +23,6 @@ import org.msgpack.value.Value;
 
 public class StringColumnSetter extends AbstractDynamicColumnSetter {
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
-    private final org.embulk.spi.time.TimestampFormatter timestampFormatter;
-
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
     public StringColumnSetter(PageBuilder pageBuilder, Column column,
             DefaultValueSetter defaultValue,
             org.embulk.spi.time.TimestampFormatter timestampFormatter) {
@@ -74,4 +71,7 @@ public class StringColumnSetter extends AbstractDynamicColumnSetter {
     public void set(Value v) {
         pageBuilder.setString(column, v.toJson());
     }
+
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
+    private final org.embulk.spi.time.TimestampFormatter timestampFormatter;
 }

--- a/src/main/java/org/embulk/util/dynamic/StringColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/StringColumnSetter.java
@@ -23,53 +23,55 @@ import org.msgpack.value.Value;
 
 public class StringColumnSetter extends AbstractDynamicColumnSetter {
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
-    public StringColumnSetter(PageBuilder pageBuilder, Column column,
-            DefaultValueSetter defaultValue,
-            org.embulk.spi.time.TimestampFormatter timestampFormatter) {
-        super(pageBuilder, column, defaultValue);
+    public StringColumnSetter(
+            final PageBuilder pageBuilder,
+            final Column column,
+            final DefaultValueSetter defaultValueSetter,
+            final org.embulk.spi.time.TimestampFormatter timestampFormatter) {
+        super(pageBuilder, column, defaultValueSetter);
         this.timestampFormatter = timestampFormatter;
     }
 
     @Override
     public void setNull() {
-        pageBuilder.setNull(column);
+        this.pageBuilder.setNull(this.column);
     }
 
     @Override
-    public void set(boolean v) {
-        pageBuilder.setString(column, Boolean.toString(v));
+    public void set(final boolean v) {
+        this.pageBuilder.setString(this.column, Boolean.toString(v));
     }
 
     @Override
-    public void set(long v) {
-        pageBuilder.setString(column, Long.toString(v));
+    public void set(final long v) {
+        this.pageBuilder.setString(this.column, Long.toString(v));
     }
 
     @Override
-    public void set(double v) {
-        pageBuilder.setString(column, Double.toString(v));
+    public void set(final double v) {
+        this.pageBuilder.setString(this.column, Double.toString(v));
     }
 
     @Override
-    public void set(String v) {
-        pageBuilder.setString(column, v);
+    public void set(final String v) {
+        this.pageBuilder.setString(this.column, v);
     }
 
     @Override
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
     public void set(final org.embulk.spi.time.Timestamp v) {
-        pageBuilder.setString(column, timestampFormatter.format(v));
+        this.pageBuilder.setString(this.column, this.timestampFormatter.format(v));
     }
 
     @Override
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
-    public void set(Instant v) {
-        pageBuilder.setString(column, timestampFormatter.format(org.embulk.spi.time.Timestamp.ofInstant(v)));
+    public void set(final Instant v) {
+        this.pageBuilder.setString(this.column, this.timestampFormatter.format(org.embulk.spi.time.Timestamp.ofInstant(v)));
     }
 
     @Override
-    public void set(Value v) {
-        pageBuilder.setString(column, v.toJson());
+    public void set(final Value v) {
+        this.pageBuilder.setString(this.column, v.toJson());
     }
 
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298

--- a/src/main/java/org/embulk/util/dynamic/TimestampColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/TimestampColumnSetter.java
@@ -23,62 +23,64 @@ import org.msgpack.value.Value;
 
 public class TimestampColumnSetter extends AbstractDynamicColumnSetter {
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
-    public TimestampColumnSetter(PageBuilder pageBuilder, Column column,
-            DefaultValueSetter defaultValue,
-            org.embulk.spi.time.TimestampParser timestampParser) {
-        super(pageBuilder, column, defaultValue);
+    public TimestampColumnSetter(
+            final PageBuilder pageBuilder,
+            final Column column,
+            final DefaultValueSetter defaultValueSetter,
+            final org.embulk.spi.time.TimestampParser timestampParser) {
+        super(pageBuilder, column, defaultValueSetter);
         this.timestampParser = timestampParser;
     }
 
     @Override
     public void setNull() {
-        pageBuilder.setNull(column);
+        this.pageBuilder.setNull(this.column);
     }
 
     @Override
-    public void set(boolean v) {
-        defaultValue.setTimestamp(pageBuilder, column);
-    }
-
-    @Override
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
-    public void set(long v) {
-        pageBuilder.setTimestamp(column, org.embulk.spi.time.Timestamp.ofEpochSecond(v));
+    public void set(final boolean v) {
+        this.defaultValueSetter.setTimestamp(this.pageBuilder, this.column);
     }
 
     @Override
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
-    public void set(double v) {
-        long sec = (long) v;
-        int nsec = (int) ((v - (double) sec) * 1000000000);
-        pageBuilder.setTimestamp(column, org.embulk.spi.time.Timestamp.ofEpochSecond(sec, nsec));
-        defaultValue.setTimestamp(pageBuilder, column);
+    public void set(final long v) {
+        this.pageBuilder.setTimestamp(this.column, org.embulk.spi.time.Timestamp.ofEpochSecond(v));
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
+    public void set(final double v) {
+        final long sec = (long) v;
+        final int nsec = (int) ((v - (double) sec) * 1000000000);
+        this.pageBuilder.setTimestamp(this.column, org.embulk.spi.time.Timestamp.ofEpochSecond(sec, nsec));
+        this.defaultValueSetter.setTimestamp(this.pageBuilder, this.column);
     }
 
     @Override
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
-    public void set(String v) {
+    public void set(final String v) {
         try {
-            pageBuilder.setTimestamp(column, timestampParser.parse(v));
-        } catch (org.embulk.spi.time.TimestampParseException e) {
-            defaultValue.setTimestamp(pageBuilder, column);
+            this.pageBuilder.setTimestamp(this.column, this.timestampParser.parse(v));
+        } catch (final org.embulk.spi.time.TimestampParseException ex) {
+            this.defaultValueSetter.setTimestamp(this.pageBuilder, this.column);
         }
     }
 
     @Override
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
-    public void set(org.embulk.spi.time.Timestamp v) {
-        pageBuilder.setTimestamp(column, v);
+    public void set(final org.embulk.spi.time.Timestamp v) {
+        this.pageBuilder.setTimestamp(this.column, v);
     }
 
     @Override
-    public void set(Instant v) {
-        pageBuilder.setTimestamp(column, v);
+    public void set(final Instant v) {
+        this.pageBuilder.setTimestamp(this.column, v);
     }
 
     @Override
-    public void set(Value v) {
-        defaultValue.setTimestamp(pageBuilder, column);
+    public void set(final Value v) {
+        this.defaultValueSetter.setTimestamp(this.pageBuilder, this.column);
     }
 
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298

--- a/src/main/java/org/embulk/util/dynamic/TimestampColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/TimestampColumnSetter.java
@@ -23,9 +23,6 @@ import org.msgpack.value.Value;
 
 public class TimestampColumnSetter extends AbstractDynamicColumnSetter {
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
-    private final org.embulk.spi.time.TimestampParser timestampParser;
-
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
     public TimestampColumnSetter(PageBuilder pageBuilder, Column column,
             DefaultValueSetter defaultValue,
             org.embulk.spi.time.TimestampParser timestampParser) {
@@ -83,4 +80,7 @@ public class TimestampColumnSetter extends AbstractDynamicColumnSetter {
     public void set(Value v) {
         defaultValue.setTimestamp(pageBuilder, column);
     }
+
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
+    private final org.embulk.spi.time.TimestampParser timestampParser;
 }


### PR DESCRIPTION
Coding style cleanups.
* Reordering
* Indent
* Mark `final`
* Mark `this.` to show fields explicitly
* Rename `defaultValue` to `defaultValueSetter`
