### PR TITLE
Remove as much use of org.embulk.spi.time.Timestamp as possible

### DIFF
--- a/src/main/java/org/embulk/util/dynamic/AbstractDynamicColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/AbstractDynamicColumnSetter.java
@@ -46,16 +46,8 @@ public abstract class AbstractDynamicColumnSetter implements DynamicColumnSetter
     @Override
     public abstract void set(String value);
 
-    @Deprecated
     @Override
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
-    public abstract void set(org.embulk.spi.time.Timestamp value);
-
-    @Override
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
-    public void set(final Instant value) {
-        this.set(org.embulk.spi.time.Timestamp.ofInstant(value));
-    }
+    public abstract void set(Instant value);
 
     @Override
     public abstract void set(Value value);

--- a/src/main/java/org/embulk/util/dynamic/BooleanColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/BooleanColumnSetter.java
@@ -60,12 +60,6 @@ public class BooleanColumnSetter extends AbstractDynamicColumnSetter {
     }
 
     @Override
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
-    public void set(final org.embulk.spi.time.Timestamp v) {
-        this.defaultValueSetter.setBoolean(this.pageBuilder, this.column);
-    }
-
-    @Override
     public void set(final Instant v) {
         this.defaultValueSetter.setBoolean(this.pageBuilder, this.column);
     }

--- a/src/main/java/org/embulk/util/dynamic/DoubleColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/DoubleColumnSetter.java
@@ -62,14 +62,6 @@ public class DoubleColumnSetter extends AbstractDynamicColumnSetter {
     }
 
     @Override
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
-    public void set(final org.embulk.spi.time.Timestamp v) {
-        final double sec = (double) v.getEpochSecond();
-        final double frac = v.getNano() / 1000000000.0;
-        this.pageBuilder.setDouble(this.column, sec + frac);
-    }
-
-    @Override
     public void set(final Instant v) {
         final double sec = (double) v.getEpochSecond();
         final double frac = v.getNano() / 1000000000.0;

--- a/src/main/java/org/embulk/util/dynamic/DynamicColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/DynamicColumnSetter.java
@@ -30,14 +30,7 @@ public interface DynamicColumnSetter {
 
     void set(String value);
 
-    @Deprecated
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
-    void set(org.embulk.spi.time.Timestamp value);
-
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
-    default void set(Instant value) {
-        this.set(org.embulk.spi.time.Timestamp.ofInstant(value));
-    }
+    void set(Instant value);
 
     void set(Value value);
 }

--- a/src/main/java/org/embulk/util/dynamic/JsonColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/JsonColumnSetter.java
@@ -60,12 +60,6 @@ public class JsonColumnSetter extends AbstractDynamicColumnSetter {
 
     @Override
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
-    public void set(final org.embulk.spi.time.Timestamp v) {
-        this.pageBuilder.setJson(this.column, ValueFactory.newString(timestampFormatter.format(v)));
-    }
-
-    @Override
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
     public void set(final Instant v) {
         this.pageBuilder.setJson(this.column, ValueFactory.newString(timestampFormatter.format(org.embulk.spi.time.Timestamp.ofInstant(v))));
     }

--- a/src/main/java/org/embulk/util/dynamic/LongColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/LongColumnSetter.java
@@ -73,12 +73,6 @@ public class LongColumnSetter extends AbstractDynamicColumnSetter {
     }
 
     @Override
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
-    public void set(final org.embulk.spi.time.Timestamp v) {
-        this.pageBuilder.setLong(this.column, v.getEpochSecond());
-    }
-
-    @Override
     public void set(final Instant v) {
         this.pageBuilder.setLong(this.column, v.getEpochSecond());
     }

--- a/src/main/java/org/embulk/util/dynamic/SkipColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/SkipColumnSetter.java
@@ -44,10 +44,6 @@ public class SkipColumnSetter extends AbstractDynamicColumnSetter {
     public void set(final String v) {}
 
     @Override
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
-    public void set(final org.embulk.spi.time.Timestamp v) {}
-
-    @Override
     public void set(final Instant v) {}
 
     @Override

--- a/src/main/java/org/embulk/util/dynamic/StringColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/StringColumnSetter.java
@@ -59,12 +59,6 @@ public class StringColumnSetter extends AbstractDynamicColumnSetter {
 
     @Override
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
-    public void set(final org.embulk.spi.time.Timestamp v) {
-        this.pageBuilder.setString(this.column, this.timestampFormatter.format(v));
-    }
-
-    @Override
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
     public void set(final Instant v) {
         this.pageBuilder.setString(this.column, this.timestampFormatter.format(org.embulk.spi.time.Timestamp.ofInstant(v)));
     }

--- a/src/main/java/org/embulk/util/dynamic/TimestampColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/TimestampColumnSetter.java
@@ -68,12 +68,6 @@ public class TimestampColumnSetter extends AbstractDynamicColumnSetter {
     }
 
     @Override
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
-    public void set(final org.embulk.spi.time.Timestamp v) {
-        this.pageBuilder.setTimestamp(this.column, v);
-    }
-
-    @Override
     public void set(final Instant v) {
         this.pageBuilder.setTimestamp(this.column, v);
     }


### PR DESCRIPTION
`org.embulk.spi.time.Timestamp` has been deprecated. Recent Embulk is using `java.time.Instant`. Although Embulk still has `org.embulk.spi.time.Timestamp` for compatibility, this new independent library no longer needs to use it.