### PR TITLE
Replace embulk-core's TimestampFormatter/Parser to embulk-util-timestamp

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "java"
+    id "java-library"
     id "maven-publish"
     id "signing"
     id "checkstyle"
@@ -26,6 +27,8 @@ dependencies {
     compileOnly "org.embulk:embulk-api:0.10.17"
     compileOnly "org.embulk:embulk-spi:0.10.17"
     compileOnly "org.embulk:embulk-core:0.10.17"
+
+    api "org.embulk:embulk-util-timestamp:0.2.1"
 
     testImplementation "org.embulk:embulk-api:0.10.17"
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.6.1"

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -22,6 +22,7 @@ org.apache.commons:commons-lang3:3.4
 org.embulk:embulk-api:0.10.17
 org.embulk:embulk-core:0.10.17
 org.embulk:embulk-spi:0.10.17
+org.embulk:embulk-util-timestamp:0.2.1
 org.jruby:jruby-complete:9.1.15.0
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.12

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,3 +1,5 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+org.embulk:embulk-util-rubytime:0.3.2
+org.embulk:embulk-util-timestamp:0.2.1

--- a/src/main/java/org/embulk/util/dynamic/JsonColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/JsonColumnSetter.java
@@ -19,16 +19,16 @@ package org.embulk.util.dynamic;
 import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
+import org.embulk.util.timestamp.TimestampFormatter;
 import org.msgpack.value.Value;
 import org.msgpack.value.ValueFactory;
 
 public class JsonColumnSetter extends AbstractDynamicColumnSetter {
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
     public JsonColumnSetter(
             final PageBuilder pageBuilder,
             final Column column,
             final DefaultValueSetter defaultValueSetter,
-            final org.embulk.spi.time.TimestampFormatter timestampFormatter) {
+            final TimestampFormatter timestampFormatter) {
         super(pageBuilder, column, defaultValueSetter);
         this.timestampFormatter = timestampFormatter;
     }
@@ -59,9 +59,8 @@ public class JsonColumnSetter extends AbstractDynamicColumnSetter {
     }
 
     @Override
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
     public void set(final Instant v) {
-        this.pageBuilder.setJson(this.column, ValueFactory.newString(timestampFormatter.format(org.embulk.spi.time.Timestamp.ofInstant(v))));
+        this.pageBuilder.setJson(this.column, ValueFactory.newString(timestampFormatter.format(v)));
     }
 
     @Override
@@ -69,6 +68,5 @@ public class JsonColumnSetter extends AbstractDynamicColumnSetter {
         this.pageBuilder.setJson(this.column, v);
     }
 
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
-    private final org.embulk.spi.time.TimestampFormatter timestampFormatter;
+    private final TimestampFormatter timestampFormatter;
 }

--- a/src/main/java/org/embulk/util/dynamic/StringColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/StringColumnSetter.java
@@ -19,15 +19,15 @@ package org.embulk.util.dynamic;
 import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
+import org.embulk.util.timestamp.TimestampFormatter;
 import org.msgpack.value.Value;
 
 public class StringColumnSetter extends AbstractDynamicColumnSetter {
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
     public StringColumnSetter(
             final PageBuilder pageBuilder,
             final Column column,
             final DefaultValueSetter defaultValueSetter,
-            final org.embulk.spi.time.TimestampFormatter timestampFormatter) {
+            final TimestampFormatter timestampFormatter) {
         super(pageBuilder, column, defaultValueSetter);
         this.timestampFormatter = timestampFormatter;
     }
@@ -58,9 +58,8 @@ public class StringColumnSetter extends AbstractDynamicColumnSetter {
     }
 
     @Override
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
     public void set(final Instant v) {
-        this.pageBuilder.setString(this.column, this.timestampFormatter.format(org.embulk.spi.time.Timestamp.ofInstant(v)));
+        this.pageBuilder.setString(this.column, this.timestampFormatter.format(v));
     }
 
     @Override
@@ -68,6 +67,5 @@ public class StringColumnSetter extends AbstractDynamicColumnSetter {
         this.pageBuilder.setString(this.column, v.toJson());
     }
 
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
-    private final org.embulk.spi.time.TimestampFormatter timestampFormatter;
+    private final TimestampFormatter timestampFormatter;
 }


### PR DESCRIPTION
It also implements a mechanism to use `PageBuilder#setTimestamp(Column, Instant)` when available.