### PR TITLE
Replace embulk-core's TimestampFormatter/Parser to embulk-util-timestamp

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "java"
+    id "java-library"
     id "maven-publish"
     id "signing"
     id "checkstyle"
@@ -26,6 +27,8 @@ dependencies {
     compileOnly "org.embulk:embulk-api:0.10.17"
     compileOnly "org.embulk:embulk-spi:0.10.17"
     compileOnly "org.embulk:embulk-core:0.10.17"
+
+    api "org.embulk:embulk-util-timestamp:0.2.1"
 
     testImplementation "org.embulk:embulk-api:0.10.17"
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.6.1"

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -22,6 +22,7 @@ org.apache.commons:commons-lang3:3.4
 org.embulk:embulk-api:0.10.17
 org.embulk:embulk-core:0.10.17
 org.embulk:embulk-spi:0.10.17
+org.embulk:embulk-util-timestamp:0.2.1
 org.jruby:jruby-complete:9.1.15.0
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.12

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,3 +1,5 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+org.embulk:embulk-util-rubytime:0.3.2
+org.embulk:embulk-util-timestamp:0.2.1

--- a/src/main/java/org/embulk/util/dynamic/DynamicColumnSetterFactory.java
+++ b/src/main/java/org/embulk/util/dynamic/DynamicColumnSetterFactory.java
@@ -27,6 +27,7 @@ import org.embulk.spi.type.LongType;
 import org.embulk.spi.type.StringType;
 import org.embulk.spi.type.TimestampType;
 import org.embulk.spi.type.Type;
+import org.embulk.util.timestamp.TimestampFormatter;
 
 class DynamicColumnSetterFactory {
     private DynamicColumnSetterFactory(
@@ -64,24 +65,28 @@ class DynamicColumnSetterFactory {
         } else if (type instanceof DoubleType) {
             return new DoubleColumnSetter(pageBuilder, column, this.defaultValueSetter);
         } else if (type instanceof StringType) {
-            final org.embulk.spi.time.TimestampFormatter formatter = org.embulk.spi.time.TimestampFormatter.of(
-                    getTimestampFormatForFormatter(column), getTimeZoneId(column));
+            final TimestampFormatter formatter = TimestampFormatter.builder(getTimestampFormatForFormatter(column), true)
+                    .setDefaultZoneFromString(getTimeZoneId(column))
+                    .build();
             return new StringColumnSetter(pageBuilder, column, this.defaultValueSetter, formatter);
         } else if (type instanceof TimestampType) {
-            // TODO use flexible time format like Ruby's Time.parse
-            final org.embulk.spi.time.TimestampParser parser;
+            final TimestampFormatter parser;
             if (this.useColumnForTimestampMetadata) {
                 final TimestampType timestampType = (TimestampType) type;
-                // https://github.com/embulk/embulk/issues/935
-                parser = org.embulk.spi.time.TimestampParser.of(
-                        getFormatFromTimestampTypeWithDepracationSuppressed(timestampType), getTimeZoneId(column));
+                // TODO: Remove use of TimestampType's format. See: https://github.com/embulk/embulk/issues/935
+                parser = TimestampFormatter.builder(getFormatFromTimestampTypeWithDepracationSuppressed(timestampType), true)
+                        .setDefaultZoneFromString(getTimeZoneId(column))
+                        .build();
             } else {
-                parser = org.embulk.spi.time.TimestampParser.of(getTimestampFormatForParser(column), getTimeZoneId(column));
+                parser = TimestampFormatter.builder(getTimestampFormatForParser(column), true)
+                        .setDefaultZoneFromString(getTimeZoneId(column))
+                        .build();
             }
             return new TimestampColumnSetter(pageBuilder, column, this.defaultValueSetter, parser);
         } else if (type instanceof JsonType) {
-            final org.embulk.spi.time.TimestampFormatter formatter = org.embulk.spi.time.TimestampFormatter.of(
-                    getTimestampFormatForFormatter(column), getTimeZoneId(column));
+            final TimestampFormatter formatter = TimestampFormatter.builder(getTimestampFormatForFormatter(column), true)
+                    .setDefaultZoneFromString(getTimeZoneId(column))
+                    .build();
             return new JsonColumnSetter(pageBuilder, column, this.defaultValueSetter, formatter);
         }
         throw new ConfigException("Unknown column type: " + type);

--- a/src/main/java/org/embulk/util/dynamic/JsonColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/JsonColumnSetter.java
@@ -19,16 +19,16 @@ package org.embulk.util.dynamic;
 import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
+import org.embulk.util.timestamp.TimestampFormatter;
 import org.msgpack.value.Value;
 import org.msgpack.value.ValueFactory;
 
 public class JsonColumnSetter extends AbstractDynamicColumnSetter {
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
     public JsonColumnSetter(
             final PageBuilder pageBuilder,
             final Column column,
             final DefaultValueSetter defaultValueSetter,
-            final org.embulk.spi.time.TimestampFormatter timestampFormatter) {
+            final TimestampFormatter timestampFormatter) {
         super(pageBuilder, column, defaultValueSetter);
         this.timestampFormatter = timestampFormatter;
     }
@@ -59,9 +59,8 @@ public class JsonColumnSetter extends AbstractDynamicColumnSetter {
     }
 
     @Override
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
     public void set(final Instant v) {
-        this.pageBuilder.setJson(this.column, ValueFactory.newString(timestampFormatter.format(org.embulk.spi.time.Timestamp.ofInstant(v))));
+        this.pageBuilder.setJson(this.column, ValueFactory.newString(timestampFormatter.format(v)));
     }
 
     @Override
@@ -69,6 +68,5 @@ public class JsonColumnSetter extends AbstractDynamicColumnSetter {
         this.pageBuilder.setJson(this.column, v);
     }
 
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
-    private final org.embulk.spi.time.TimestampFormatter timestampFormatter;
+    private final TimestampFormatter timestampFormatter;
 }

--- a/src/main/java/org/embulk/util/dynamic/StringColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/StringColumnSetter.java
@@ -19,15 +19,15 @@ package org.embulk.util.dynamic;
 import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
+import org.embulk.util.timestamp.TimestampFormatter;
 import org.msgpack.value.Value;
 
 public class StringColumnSetter extends AbstractDynamicColumnSetter {
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
     public StringColumnSetter(
             final PageBuilder pageBuilder,
             final Column column,
             final DefaultValueSetter defaultValueSetter,
-            final org.embulk.spi.time.TimestampFormatter timestampFormatter) {
+            final TimestampFormatter timestampFormatter) {
         super(pageBuilder, column, defaultValueSetter);
         this.timestampFormatter = timestampFormatter;
     }
@@ -58,9 +58,8 @@ public class StringColumnSetter extends AbstractDynamicColumnSetter {
     }
 
     @Override
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
     public void set(final Instant v) {
-        this.pageBuilder.setString(this.column, this.timestampFormatter.format(org.embulk.spi.time.Timestamp.ofInstant(v)));
+        this.pageBuilder.setString(this.column, this.timestampFormatter.format(v));
     }
 
     @Override
@@ -68,6 +67,5 @@ public class StringColumnSetter extends AbstractDynamicColumnSetter {
         this.pageBuilder.setString(this.column, v.toJson());
     }
 
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
-    private final org.embulk.spi.time.TimestampFormatter timestampFormatter;
+    private final TimestampFormatter timestampFormatter;
 }

--- a/src/main/java/org/embulk/util/dynamic/TimestampColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/TimestampColumnSetter.java
@@ -17,17 +17,18 @@
 package org.embulk.util.dynamic;
 
 import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
+import org.embulk.util.timestamp.TimestampFormatter;
 import org.msgpack.value.Value;
 
 public class TimestampColumnSetter extends AbstractDynamicColumnSetter {
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
     public TimestampColumnSetter(
             final PageBuilder pageBuilder,
             final Column column,
             final DefaultValueSetter defaultValueSetter,
-            final org.embulk.spi.time.TimestampParser timestampParser) {
+            final TimestampFormatter timestampParser) {
         super(pageBuilder, column, defaultValueSetter);
         this.timestampParser = timestampParser;
     }
@@ -45,7 +46,20 @@ public class TimestampColumnSetter extends AbstractDynamicColumnSetter {
     @Override
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
     public void set(final long v) {
-        this.pageBuilder.setTimestamp(this.column, org.embulk.spi.time.Timestamp.ofEpochSecond(v));
+        if (HAS_SET_TIMESTAMP_INSTANT) {
+            this.pageBuilder.setTimestamp(this.column, Instant.ofEpochSecond(v));
+        } else if (HAS_SET_TIMESTAMP_TIMESTAMP) {
+            // This embulk-util-dynamic is still to be used in plugins for Embulk v0.9.*,
+            // but PageBuilder.setTimestamp(Column, Instant) is added in recently v0.10.13.
+            // https://github.com/embulk/embulk/pull/1294
+            //
+            // TODO: Stop the reflection tweak, and always call PageBuilder#setTimestamp(Column, Instant) for Embulk 0.11+.
+            // https://github.com/embulk/embulk-util-dynamic/issues/5
+            this.pageBuilder.setTimestamp(this.column, org.embulk.spi.time.Timestamp.ofEpochSecond(v));
+        } else {
+            throw new IllegalStateException(
+                    "Neither PageBuilder#setTimestamp(Column, Instant) nor PageBuilder#setTimestamp(Column, Timestamp) found.");
+        }
     }
 
     @Override
@@ -53,23 +67,66 @@ public class TimestampColumnSetter extends AbstractDynamicColumnSetter {
     public void set(final double v) {
         final long sec = (long) v;
         final int nsec = (int) ((v - (double) sec) * 1000000000);
-        this.pageBuilder.setTimestamp(this.column, org.embulk.spi.time.Timestamp.ofEpochSecond(sec, nsec));
+
+        if (HAS_SET_TIMESTAMP_INSTANT) {
+            this.pageBuilder.setTimestamp(this.column, Instant.ofEpochSecond(sec, nsec));
+        } else if (HAS_SET_TIMESTAMP_TIMESTAMP) {
+            // This embulk-util-dynamic is still to be used in plugins for Embulk v0.9.*,
+            // but PageBuilder.setTimestamp(Column, Instant) is added in recently v0.10.13.
+            // https://github.com/embulk/embulk/pull/1294
+            //
+            // TODO: Stop the reflection tweak, and always call PageBuilder#setTimestamp(Column, Instant) for Embulk 0.11+.
+            // https://github.com/embulk/embulk-util-dynamic/issues/5
+            this.pageBuilder.setTimestamp(this.column, org.embulk.spi.time.Timestamp.ofEpochSecond(sec, nsec));
+        }
+
         this.defaultValueSetter.setTimestamp(this.pageBuilder, this.column);
     }
 
     @Override
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
     public void set(final String v) {
+        final Instant parsed;
         try {
-            this.pageBuilder.setTimestamp(this.column, this.timestampParser.parse(v));
-        } catch (final org.embulk.spi.time.TimestampParseException ex) {
+            parsed = this.timestampParser.parse(v);
+        } catch (final DateTimeParseException ex) {
             this.defaultValueSetter.setTimestamp(this.pageBuilder, this.column);
+            return;
+        }
+
+        if (HAS_SET_TIMESTAMP_INSTANT) {
+            this.pageBuilder.setTimestamp(this.column, parsed);
+        } else if (HAS_SET_TIMESTAMP_TIMESTAMP) {
+            // This embulk-util-dynamic is still to be used in plugins for Embulk v0.9.*,
+            // but PageBuilder.setTimestamp(Column, Instant) is added in recently v0.10.13.
+            // https://github.com/embulk/embulk/pull/1294
+            //
+            // TODO: Stop the reflection tweak, and always call PageBuilder#setTimestamp(Column, Instant) for Embulk 0.11+.
+            // https://github.com/embulk/embulk-util-dynamic/issues/5
+            this.pageBuilder.setTimestamp(this.column, org.embulk.spi.time.Timestamp.ofInstant(parsed));
+        } else {
+            throw new IllegalStateException(
+                    "Neither PageBuilder#setTimestamp(Column, Instant) nor PageBuilder#setTimestamp(Column, Timestamp) found.");
         }
     }
 
     @Override
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
     public void set(final Instant v) {
-        this.pageBuilder.setTimestamp(this.column, v);
+        if (HAS_SET_TIMESTAMP_INSTANT) {
+            this.pageBuilder.setTimestamp(this.column, v);
+        } else if (HAS_SET_TIMESTAMP_TIMESTAMP) {
+            // This embulk-util-dynamic is still to be used in plugins for Embulk v0.9.*,
+            // but PageBuilder.setTimestamp(Column, Instant) is added in recently v0.10.13.
+            // https://github.com/embulk/embulk/pull/1294
+            //
+            // TODO: Stop the reflection tweak, and always call PageBuilder#setTimestamp(Column, Instant) for Embulk 0.11+.
+            // https://github.com/embulk/embulk-util-dynamic/issues/5
+            this.pageBuilder.setTimestamp(this.column, org.embulk.spi.time.Timestamp.ofInstant(v));
+        } else {
+            throw new IllegalStateException(
+                    "Neither PageBuilder#setTimestamp(Column, Instant) nor PageBuilder#setTimestamp(Column, Timestamp) found.");
+        }
     }
 
     @Override
@@ -77,6 +134,28 @@ public class TimestampColumnSetter extends AbstractDynamicColumnSetter {
         this.defaultValueSetter.setTimestamp(this.pageBuilder, this.column);
     }
 
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
-    private final org.embulk.spi.time.TimestampParser timestampParser;
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
+    private static boolean hasSetTimestampTimestamp() {
+        try {
+            PageBuilder.class.getMethod("setTimestamp", Column.class, org.embulk.spi.time.Timestamp.class);
+        } catch (final NoSuchMethodException ex) {
+            return false;
+        }
+        return true;
+    }
+
+    private static boolean hasSetTimestampInstant() {
+        try {
+            PageBuilder.class.getMethod("setTimestamp", Column.class, Instant.class);
+        } catch (final NoSuchMethodException ex) {
+            return false;
+        }
+        return true;
+    }
+
+    private static final boolean HAS_SET_TIMESTAMP_INSTANT = hasSetTimestampInstant();
+
+    private static final boolean HAS_SET_TIMESTAMP_TIMESTAMP = hasSetTimestampTimestamp();
+
+    private final TimestampFormatter timestampParser;
 }


### PR DESCRIPTION
`embulk-core`'s embedded `TimestampFormatter` and `TimestampParser` have been deprecated. Plugins should use another independent library `embulk-util-timestamp`.

It also implements a mechanism to use `PageBuilder#setTimestamp(Column, Instant)` when available.