### PR TITLE
Receive PageBuilder not to create one by itself

### DIFF
--- a/src/main/java/org/embulk/util/dynamic/DynamicPageBuilder.java
+++ b/src/main/java/org/embulk/util/dynamic/DynamicPageBuilder.java
@@ -31,9 +31,10 @@ public class DynamicPageBuilder implements AutoCloseable {
     private DynamicPageBuilder(
             final DynamicColumnSetterFactory factory,
             final BufferAllocator allocator,
+            final PageBuilder pageBuilder,
             final Schema schema,
             final PageOutput output) {
-        this.pageBuilder = new PageBuilder(allocator, schema, output);
+        this.pageBuilder = pageBuilder;
         this.schema = schema;
         final ImmutableList.Builder<DynamicColumnSetter> setters = ImmutableList.builder();
         final ImmutableMap.Builder<String, DynamicColumnSetter> lookup = ImmutableMap.builder();
@@ -50,24 +51,26 @@ public class DynamicPageBuilder implements AutoCloseable {
             final String defaultZoneString,
             final Map<String, ConfigSource> columnOptions,
             final BufferAllocator allocator,
+            final PageBuilder pageBuilder,
             final Schema schema,
             final PageOutput output) {
         // TODO configurable default value
         final DynamicColumnSetterFactory factory = DynamicColumnSetterFactory.createWithTimestampMetadata(
                 defaultZoneString, columnOptions, DynamicColumnSetterFactory.nullDefaultValueSetter());
-        return new DynamicPageBuilder(factory, allocator, schema, output);
+        return new DynamicPageBuilder(factory, allocator, pageBuilder, schema, output);
     }
 
     public static DynamicPageBuilder createWithTimestampMetadataFromColumn(
             final String defaultZoneString,
             final Map<String, ConfigSource> columnOptions,
             final BufferAllocator allocator,
+            final PageBuilder pageBuilder,
             final Schema schema,
             final PageOutput output) {
         // TODO configurable default value
         final DynamicColumnSetterFactory factory = DynamicColumnSetterFactory.createWithTimestampMetadataFromColumn(
                 defaultZoneString, columnOptions, DynamicColumnSetterFactory.nullDefaultValueSetter());
-        return new DynamicPageBuilder(factory, allocator, schema, output);
+        return new DynamicPageBuilder(factory, allocator, pageBuilder, schema, output);
     }
 
     public List<Column> getColumns() {


### PR DESCRIPTION
Constructing `new PageBuilder` is now deprecated. Plugins can receive it by `org.embulk.spi.Exec.getPageBuilder`, but it is only in newer `embulk-api`.

Instead, receiving `PageBuilder` from a user of this library is much simple.