### PR TITLE
Remove Guava

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,10 @@ dependencies {
     testImplementation "org.embulk:embulk-api:0.10.17"
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.6.1"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.6.1"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:5.6.1"
+
+    testImplementation "org.mockito:mockito-core:3.9.0"
+    testImplementation "org.mockito:mockito-junit-jupiter:3.9.0"
 }
 
 tasks.withType(JavaCompile) {

--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,6 @@ repositories {
 
 dependencies {
     compileOnly "org.embulk:embulk-api:0.10.17"
-    compileOnly "org.embulk:embulk-spi:0.10.17"
-    compileOnly "org.embulk:embulk-core:0.10.17"
 
     api "org.embulk:embulk-util-timestamp:0.2.1"
 

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,28 +1,6 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-aopalliance:aopalliance:1.0
-com.fasterxml.jackson.core:jackson-annotations:2.6.7
-com.fasterxml.jackson.core:jackson-core:2.6.7
-com.fasterxml.jackson.core:jackson-databind:2.6.7
-com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7
-com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
-com.fasterxml.jackson.datatype:jackson-datatype-joda:2.6.7
-com.fasterxml.jackson.module:jackson-module-guice:2.6.7
-com.google.guava:guava:18.0
-com.google.inject.extensions:guice-multibindings:4.0
-com.google.inject:guice:4.0
-commons-beanutils:commons-beanutils-core:1.8.3
-javax.inject:javax.inject:1
-javax.validation:validation-api:1.1.0.Final
-joda-time:joda-time:2.9.2
-org.apache.bval:bval-core:0.5
-org.apache.bval:bval-jsr303:0.5
-org.apache.commons:commons-lang3:3.4
 org.embulk:embulk-api:0.10.17
-org.embulk:embulk-core:0.10.17
-org.embulk:embulk-spi:0.10.17
 org.embulk:embulk-util-timestamp:0.2.1
-org.jruby:jruby-complete:9.1.15.0
 org.msgpack:msgpack-core:0.8.11
-org.slf4j:slf4j-api:1.7.12

--- a/src/main/java/org/embulk/util/dynamic/BooleanColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/BooleanColumnSetter.java
@@ -16,8 +16,11 @@
 
 package org.embulk.util.dynamic;
 
-import com.google.common.collect.ImmutableSet;
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
 import org.msgpack.value.Value;
@@ -69,10 +72,13 @@ public class BooleanColumnSetter extends AbstractDynamicColumnSetter {
         this.defaultValueSetter.setBoolean(this.pageBuilder, this.column);
     }
 
-    private static final ImmutableSet<String> TRUE_STRINGS = ImmutableSet.of(
+    private static final String[] TRUE_STRINGS_ARRAY = {
             "true", "True", "TRUE",
             "yes", "Yes", "YES",
             "t", "T", "y", "Y",
             "on", "On",
-            "ON", "1");
+            "ON", "1"};
+
+    private static final Set<String> TRUE_STRINGS = Collections.unmodifiableSet(
+            new LinkedHashSet<>(Arrays.asList(TRUE_STRINGS_ARRAY)));
 }

--- a/src/main/java/org/embulk/util/dynamic/DynamicPageBuilder.java
+++ b/src/main/java/org/embulk/util/dynamic/DynamicPageBuilder.java
@@ -16,8 +16,9 @@
 
 package org.embulk.util.dynamic;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.embulk.config.ConfigSource;
@@ -36,15 +37,15 @@ public class DynamicPageBuilder implements AutoCloseable {
             final PageOutput output) {
         this.pageBuilder = pageBuilder;
         this.schema = schema;
-        final ImmutableList.Builder<DynamicColumnSetter> setters = ImmutableList.builder();
-        final ImmutableMap.Builder<String, DynamicColumnSetter> lookup = ImmutableMap.builder();
+        final ArrayList<DynamicColumnSetter> setters = new ArrayList<>();
+        final LinkedHashMap<String, DynamicColumnSetter> lookup = new LinkedHashMap<>();
         for (final Column c : schema.getColumns()) {
             final DynamicColumnSetter setter = factory.newColumnSetter(this.pageBuilder, c);
             setters.add(setter);
             lookup.put(c.getName(), setter);
         }
-        this.setters = setters.build().toArray(new DynamicColumnSetter[0]);
-        this.columnLookup = lookup.build();
+        this.setters = setters.toArray(new DynamicColumnSetter[0]);
+        this.columnLookup = Collections.unmodifiableMap(lookup);
     }
 
     public static DynamicPageBuilder createWithTimestampMetadata(

--- a/src/main/java/org/embulk/util/dynamic/LongColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/LongColumnSetter.java
@@ -16,8 +16,6 @@
 
 package org.embulk.util.dynamic;
 
-import com.google.common.math.DoubleMath;
-import java.math.RoundingMode;
 import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
@@ -50,8 +48,15 @@ public class LongColumnSetter extends AbstractDynamicColumnSetter {
     public void set(final double v) {
         final long lv;
         try {
-            // TODO configurable rounding mode
-            lv = DoubleMath.roundToLong(v, RoundingMode.HALF_UP);
+            final double roundedDouble = Math.rint(v);
+            final double diff = v - roundedDouble;
+            if (diff == 0.5) {
+                lv = (long) (v + 0.5);
+            } else if (diff == -0.5) {
+                lv = (long) (v - 0.5);
+            } else {
+                lv = (long) roundedDouble;
+            }
         } catch (final ArithmeticException ex) {
             // NaN / Infinite / -Infinite
             this.defaultValueSetter.setLong(this.pageBuilder, this.column);

--- a/src/test/java/org/embulk/util/dynamic/TestLongColumnSetter.java
+++ b/src/test/java/org/embulk/util/dynamic/TestLongColumnSetter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.dynamic;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.embulk.spi.Column;
+import org.embulk.spi.PageBuilder;
+import org.embulk.spi.type.Types;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class TestLongColumnSetter {
+    @ParameterizedTest
+    @CsvSource({
+            "-1.500000000001, -2",
+            "-1.5, -1",
+            "-0.5, -1",
+            "-0.499999999999, 0",
+            "0.0, 0",
+            "0.2, 0",
+            "0.499999999999, 0",
+            "0.5, 1",
+            "0.7, 1",
+            "1.3, 1",
+            "1.5, 1",
+            "1.500000000001, 2",
+            "2.499999999999, 2",
+            "2.5, 3",
+    })
+    public void testDoubles(final String value, final String expected) {
+        final PageBuilder mockedPageBuilder = mock(PageBuilder.class);
+        final LongColumnSetter setter = create(mockedPageBuilder);
+        setter.set(Double.parseDouble(value));
+        verify(mockedPageBuilder).setLong(any(Column.class), eq(Long.parseLong(expected)));
+    }
+
+    private static LongColumnSetter create(final PageBuilder pageBuilder) {
+        return new LongColumnSetter(
+                pageBuilder,
+                new Column(1, "foo", Types.LONG),
+                new NullDefaultValueSetter());
+    }
+}


### PR DESCRIPTION
Guava is going to be removed from `embulk-core`. The Guava usage in this library is actually not very mandatory. Just removing them would be simple.