### PR TITLE
Upgrade embulk-api to v0.10.30

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,15 +20,14 @@ configurations {
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 dependencies {
-    compileOnly "org.embulk:embulk-api:0.10.17"
+    compileOnly "org.embulk:embulk-api:0.10.30"
 
     api "org.embulk:embulk-util-timestamp:0.2.1"
 
-    testImplementation "org.embulk:embulk-api:0.10.17"
+    testImplementation "org.embulk:embulk-api:0.10.30"
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.6.1"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.6.1"
 }
@@ -50,7 +49,7 @@ javadoc {
         encoding = "UTF-8"
         overview = "src/main/html/overview.html"
         links "https://docs.oracle.com/javase/8/docs/api/"
-        links "https://dev.embulk.org/embulk-api/0.10.17/javadoc/"
+        links "https://dev.embulk.org/embulk-api/0.10.30/javadoc/"
     }
 }
 

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,6 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-org.embulk:embulk-api:0.10.17
+org.embulk:embulk-api:0.10.30
 org.embulk:embulk-util-timestamp:0.2.1
 org.msgpack:msgpack-core:0.8.11
+org.slf4j:slf4j-api:1.7.30


### PR DESCRIPTION
Upgrading `embulk-api` dependend to v0.10.30, the latest as of Apr 22, 2021.