### PR TITLE
Set JSON values into org.embulk.spi.json.JsonValue, instead of org.msgpack.value.Value

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@ embulk-util-dynamic
 
 A clone of [`embulk-core`'s `org.embulk.spi.util.Dynamic*` classes](https://github.com/embulk/embulk/blob/v0.10.30/embulk-core/src/main/java/org/embulk/spi/util/DynamicPageBuilder.java) to do the same job on Embulk plugin's side.
 
+Versions
+---------
+
+Note that v0.1.1 and v0.2.0 are incompatible.
+
+| embulk-util-dynamic | Embulk |
+| ---- | ---- |
+| v0.1.1 | It will stop working during Embulk v1.0 for the removal of `msgpack-java`. |
+| v0.2.0 | It works only after Embulk v0.10.42. |
+
 For Embulk plugin developers
 -----------------------------
 

--- a/src/main/java/org/embulk/util/dynamic/AbstractDynamicColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/AbstractDynamicColumnSetter.java
@@ -19,7 +19,7 @@ package org.embulk.util.dynamic;
 import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
-import org.msgpack.value.Value;
+import org.embulk.spi.json.JsonValue;
 
 public abstract class AbstractDynamicColumnSetter implements DynamicColumnSetter {
     protected AbstractDynamicColumnSetter(
@@ -50,7 +50,7 @@ public abstract class AbstractDynamicColumnSetter implements DynamicColumnSetter
     public abstract void set(Instant value);
 
     @Override
-    public abstract void set(Value value);
+    public abstract void set(JsonValue value);
 
     protected final PageBuilder pageBuilder;
     protected final Column column;

--- a/src/main/java/org/embulk/util/dynamic/BooleanColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/BooleanColumnSetter.java
@@ -23,7 +23,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
-import org.msgpack.value.Value;
+import org.embulk.spi.json.JsonValue;
 
 public class BooleanColumnSetter extends AbstractDynamicColumnSetter {
     public BooleanColumnSetter(
@@ -68,7 +68,7 @@ public class BooleanColumnSetter extends AbstractDynamicColumnSetter {
     }
 
     @Override
-    public void set(final Value v) {
+    public void set(final JsonValue v) {
         this.defaultValueSetter.setBoolean(this.pageBuilder, this.column);
     }
 

--- a/src/main/java/org/embulk/util/dynamic/DoubleColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/DoubleColumnSetter.java
@@ -19,7 +19,7 @@ package org.embulk.util.dynamic;
 import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
-import org.msgpack.value.Value;
+import org.embulk.spi.json.JsonValue;
 
 public class DoubleColumnSetter extends AbstractDynamicColumnSetter {
     public DoubleColumnSetter(
@@ -69,7 +69,7 @@ public class DoubleColumnSetter extends AbstractDynamicColumnSetter {
     }
 
     @Override
-    public void set(final Value v) {
+    public void set(final JsonValue v) {
         this.defaultValueSetter.setDouble(this.pageBuilder, this.column);
     }
 }

--- a/src/main/java/org/embulk/util/dynamic/DynamicColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/DynamicColumnSetter.java
@@ -17,7 +17,7 @@
 package org.embulk.util.dynamic;
 
 import java.time.Instant;
-import org.msgpack.value.Value;
+import org.embulk.spi.json.JsonValue;
 
 public interface DynamicColumnSetter {
     void setNull();
@@ -32,5 +32,5 @@ public interface DynamicColumnSetter {
 
     void set(Instant value);
 
-    void set(Value value);
+    void set(JsonValue value);
 }

--- a/src/main/java/org/embulk/util/dynamic/JsonColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/JsonColumnSetter.java
@@ -19,9 +19,12 @@ package org.embulk.util.dynamic;
 import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
+import org.embulk.spi.json.JsonBoolean;
+import org.embulk.spi.json.JsonDouble;
+import org.embulk.spi.json.JsonLong;
+import org.embulk.spi.json.JsonString;
+import org.embulk.spi.json.JsonValue;
 import org.embulk.util.timestamp.TimestampFormatter;
-import org.msgpack.value.Value;
-import org.msgpack.value.ValueFactory;
 
 public class JsonColumnSetter extends AbstractDynamicColumnSetter {
     public JsonColumnSetter(
@@ -40,31 +43,31 @@ public class JsonColumnSetter extends AbstractDynamicColumnSetter {
 
     @Override
     public void set(final boolean v) {
-        this.pageBuilder.setJson(this.column, ValueFactory.newBoolean(v));
+        this.pageBuilder.setJson(this.column, JsonBoolean.of(v));
     }
 
     @Override
     public void set(final long v) {
-        this.pageBuilder.setJson(this.column, ValueFactory.newInteger(v));
+        this.pageBuilder.setJson(this.column, JsonLong.of(v));
     }
 
     @Override
     public void set(final double v) {
-        this.pageBuilder.setJson(this.column, ValueFactory.newFloat(v));
+        this.pageBuilder.setJson(this.column, JsonDouble.of(v));
     }
 
     @Override
     public void set(final String v) {
-        this.pageBuilder.setJson(this.column, ValueFactory.newString(v));
+        this.pageBuilder.setJson(this.column, JsonString.of(v));
     }
 
     @Override
     public void set(final Instant v) {
-        this.pageBuilder.setJson(this.column, ValueFactory.newString(timestampFormatter.format(v)));
+        this.pageBuilder.setJson(this.column, JsonString.of(this.timestampFormatter.format(v)));
     }
 
     @Override
-    public void set(final Value v) {
+    public void set(final JsonValue v) {
         this.pageBuilder.setJson(this.column, v);
     }
 

--- a/src/main/java/org/embulk/util/dynamic/LongColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/LongColumnSetter.java
@@ -19,7 +19,7 @@ package org.embulk.util.dynamic;
 import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
-import org.msgpack.value.Value;
+import org.embulk.spi.json.JsonValue;
 
 public class LongColumnSetter extends AbstractDynamicColumnSetter {
     public LongColumnSetter(
@@ -81,7 +81,7 @@ public class LongColumnSetter extends AbstractDynamicColumnSetter {
     }
 
     @Override
-    public void set(final Value v) {
+    public void set(final JsonValue v) {
         this.defaultValueSetter.setLong(this.pageBuilder, this.column);
     }
 }

--- a/src/main/java/org/embulk/util/dynamic/SkipColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/SkipColumnSetter.java
@@ -17,7 +17,7 @@
 package org.embulk.util.dynamic;
 
 import java.time.Instant;
-import org.msgpack.value.Value;
+import org.embulk.spi.json.JsonValue;
 
 public class SkipColumnSetter extends AbstractDynamicColumnSetter {
     private SkipColumnSetter() {
@@ -47,7 +47,7 @@ public class SkipColumnSetter extends AbstractDynamicColumnSetter {
     public void set(final Instant v) {}
 
     @Override
-    public void set(final Value v) {}
+    public void set(final JsonValue v) {}
 
     private static final SkipColumnSetter instance = new SkipColumnSetter();
 }

--- a/src/main/java/org/embulk/util/dynamic/StringColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/StringColumnSetter.java
@@ -19,8 +19,8 @@ package org.embulk.util.dynamic;
 import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
+import org.embulk.spi.json.JsonValue;
 import org.embulk.util.timestamp.TimestampFormatter;
-import org.msgpack.value.Value;
 
 public class StringColumnSetter extends AbstractDynamicColumnSetter {
     public StringColumnSetter(
@@ -63,7 +63,7 @@ public class StringColumnSetter extends AbstractDynamicColumnSetter {
     }
 
     @Override
-    public void set(final Value v) {
+    public void set(final JsonValue v) {
         this.pageBuilder.setString(this.column, v.toJson());
     }
 

--- a/src/main/java/org/embulk/util/dynamic/TimestampColumnSetter.java
+++ b/src/main/java/org/embulk/util/dynamic/TimestampColumnSetter.java
@@ -20,8 +20,8 @@ import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
+import org.embulk.spi.json.JsonValue;
 import org.embulk.util.timestamp.TimestampFormatter;
-import org.msgpack.value.Value;
 
 public class TimestampColumnSetter extends AbstractDynamicColumnSetter {
     public TimestampColumnSetter(
@@ -130,7 +130,7 @@ public class TimestampColumnSetter extends AbstractDynamicColumnSetter {
     }
 
     @Override
-    public void set(final Value v) {
+    public void set(final JsonValue v) {
         this.defaultValueSetter.setTimestamp(this.pageBuilder, this.column);
     }
 


### PR DESCRIPTION
Note that this is an incompatible change, but anyway, plugins would have to start using `org.embulk.spi.json.JsonValue`, not `org.msgpack.value.Value`.

If a plugin developer still want to use `org.msgpack.value.Value`, they can stay with v0.1.1.
